### PR TITLE
feat:align multilingual README and add release-on-merge workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,245 @@
+name: Release After Java CI On Master
+
+on:
+  workflow_run:
+    workflows:
+      - Java CI with Maven
+    types:
+      - completed
+    branches:
+      - master
+
+permissions:
+  contents: write
+  checks: read
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out push commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Resolve release context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          fail_with_summary() {
+            local reason="$1"
+            local version_source="$2"
+            local previous_source="$3"
+            local compared_refs="$4"
+
+            {
+              echo "RELEASE_RESULT=failed"
+              echo "RELEASE_REASON=${reason}"
+              echo "RELEASE_CURRENT_VERSION=${CURRENT_VERSION:-}"
+              echo "RELEASE_VERSION_SOURCE=${version_source}"
+              echo "RELEASE_PREVIOUS_VERSION=${PREVIOUS_VERSION:-}"
+              echo "RELEASE_PREVIOUS_SOURCE=${previous_source}"
+              echo "RELEASE_COMPARED_REFS=${compared_refs}"
+            } >> "$GITHUB_ENV"
+            exit 1
+          }
+
+          VERSION_SOURCE="mvn help:evaluate (project.version)"
+          PREVIOUS_SOURCE="check_suite.before"
+
+          CURRENT_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version --file pom.xml | tail -n 1 | tr -d '\r')
+          if [ -z "${CURRENT_VERSION}" ]; then
+            fail_with_summary \
+              "failed to resolve current project.version" \
+              "${VERSION_SOURCE}" \
+              "" \
+              "unavailable -> ${{ github.event.workflow_run.head_sha }}"
+          fi
+
+          BEFORE_REF=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/check-suites/${{ github.event.workflow_run.check_suite_id }}" \
+            | jq -r '.before // ""')
+
+          COMPARABLE=false
+          CHANGED=false
+          REASON="before ref unavailable"
+          PREVIOUS_VERSION=""
+          REF_OUTPUT="${BEFORE_REF}"
+
+          if [ -z "${BEFORE_REF}" ] || [ "${BEFORE_REF}" = "0000000000000000000000000000000000000000" ]; then
+            REF_OUTPUT="unavailable"
+          elif git cat-file -e "${BEFORE_REF}:pom.xml" 2>/dev/null; then
+            PREVIOUS_POM=$(mktemp)
+            trap 'rm -f "${PREVIOUS_POM}"' EXIT
+
+            git show "${BEFORE_REF}:pom.xml" > "${PREVIOUS_POM}"
+            PREVIOUS_SOURCE="check_suite.before + mvn help:evaluate (project.version)"
+            PREVIOUS_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version --file "${PREVIOUS_POM}" | tail -n 1 | tr -d '\r')
+
+            if [ -z "${PREVIOUS_VERSION}" ]; then
+              fail_with_summary \
+                "failed to resolve previous project.version" \
+                "${VERSION_SOURCE}" \
+                "${PREVIOUS_SOURCE}" \
+                "${BEFORE_REF} -> ${{ github.event.workflow_run.head_sha }}"
+            fi
+
+            COMPARABLE=true
+            REASON="comparable"
+            if [ "${CURRENT_VERSION}" = "${PREVIOUS_VERSION}" ]; then
+              CHANGED=false
+              REASON="version unchanged"
+            else
+              CHANGED=true
+              REASON="version changed"
+            fi
+          else
+            REASON="pom.xml missing in previous ref"
+          fi
+
+          echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "source=${VERSION_SOURCE}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF_OUTPUT}" >> "$GITHUB_OUTPUT"
+          echo "previous_version=${PREVIOUS_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "previous_source=${PREVIOUS_SOURCE}" >> "$GITHUB_OUTPUT"
+          echo "comparable=${COMPARABLE}" >> "$GITHUB_OUTPUT"
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+          echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish tag and release
+        id: publish
+        if: steps.context.outputs.comparable == 'true' && steps.context.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          fail_publish() {
+            local reason="$1"
+
+            {
+              echo "RELEASE_RESULT=failed"
+              echo "RELEASE_REASON=${reason}"
+              echo "RELEASE_CURRENT_VERSION=${{ steps.context.outputs.version }}"
+              echo "RELEASE_VERSION_SOURCE=${{ steps.context.outputs.source }}"
+              echo "RELEASE_PREVIOUS_VERSION=${{ steps.context.outputs.previous_version }}"
+              echo "RELEASE_PREVIOUS_SOURCE=${{ steps.context.outputs.previous_source }}"
+              echo "RELEASE_COMPARED_REFS=${{ steps.context.outputs.ref }} -> ${{ github.event.workflow_run.head_sha }}"
+              echo "RELEASE_TAG=${{ steps.context.outputs.tag }}"
+              echo "RELEASE_TAG_EXISTS=${TAG_EXISTS}"
+              echo "RELEASE_RELEASE_EXISTS=${RELEASE_EXISTS}"
+            } >> "$GITHUB_ENV"
+            exit 1
+          }
+
+          TAG_EXISTS=false
+          RELEASE_EXISTS=false
+
+          if git rev-parse -q --verify "refs/tags/${{ steps.context.outputs.tag }}" >/dev/null 2>&1; then
+            TAG_EXISTS=true
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag "${{ steps.context.outputs.tag }}" "${{ github.event.workflow_run.head_sha }}" || fail_publish "failed to create tag"
+            git push origin "${{ steps.context.outputs.tag }}" || fail_publish "failed to push tag"
+          fi
+
+          if gh release view "${{ steps.context.outputs.tag }}" >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          else
+            gh release create "${{ steps.context.outputs.tag }}" \
+              --target "${{ github.event.workflow_run.head_sha }}" \
+              --title "${{ steps.context.outputs.tag }}" \
+              --generate-notes || fail_publish "failed to create GitHub release"
+          fi
+
+          echo "tag_exists=${TAG_EXISTS}" >> "$GITHUB_OUTPUT"
+          echo "release_exists=${RELEASE_EXISTS}" >> "$GITHUB_OUTPUT"
+
+      - name: Write release summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Release summary"
+            echo ""
+            
+            if [ "${{ steps.context.outcome }}" = "failure" ] || [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              echo "- Result: failed"
+            elif [ "${{ steps.context.outputs.comparable }}" != "true" ]; then
+              echo "- Result: skipped"
+            elif [ "${{ steps.context.outputs.changed }}" != "true" ]; then
+              echo "- Result: skipped"
+            else
+              echo "- Result: processed"
+            fi
+            
+            if [ "${{ steps.context.outcome }}" = "failure" ] || [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              echo "- Reason: ${RELEASE_REASON}"
+              if [ -n "${RELEASE_CURRENT_VERSION}" ]; then
+                echo "- Current version: ${RELEASE_CURRENT_VERSION}"
+              fi
+              if [ -n "${RELEASE_VERSION_SOURCE}" ]; then
+                echo "- Version source: ${RELEASE_VERSION_SOURCE}"
+              fi
+            else
+              echo "- Reason: ${{ steps.context.outputs.reason }}"
+              echo "- Current version: ${{ steps.context.outputs.version }}"
+              echo "- Version source: ${{ steps.context.outputs.source }}"
+            fi
+            
+            if [ "${{ steps.context.outcome }}" = "failure" ] || [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              if [ -n "${RELEASE_PREVIOUS_VERSION}" ]; then
+                echo "- Previous version: ${RELEASE_PREVIOUS_VERSION}"
+              else
+                echo "- Previous version: unavailable"
+              fi
+            elif [ "${{ steps.context.outputs.comparable }}" != "true" ]; then
+              echo "- Previous version: unavailable"
+            else
+              echo "- Previous version: ${{ steps.context.outputs.previous_version }}"
+            fi
+            
+            if [ "${{ steps.context.outcome }}" = "failure" ] || [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              if [ -n "${RELEASE_PREVIOUS_SOURCE}" ]; then
+                echo "- Previous version source: ${RELEASE_PREVIOUS_SOURCE}"
+              fi
+            else
+              echo "- Previous version source: ${{ steps.context.outputs.previous_source }}"
+            fi
+            
+            if [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              if [ -n "${RELEASE_TAG}" ]; then
+                echo "- Tag: ${RELEASE_TAG}"
+              fi
+              if [ -n "${RELEASE_TAG_EXISTS}" ]; then
+                echo "- Tag existed: ${RELEASE_TAG_EXISTS}"
+              fi
+              if [ -n "${RELEASE_RELEASE_EXISTS}" ]; then
+                echo "- Release existed: ${RELEASE_RELEASE_EXISTS}"
+              fi
+            elif [ "${{ steps.context.outputs.comparable }}" == "true" ] && [ "${{ steps.context.outputs.changed }}" == "true" ]; then
+              echo "- Tag: ${{ steps.context.outputs.tag }}"
+              echo "- Tag existed: ${{ steps.publish.outputs.tag_exists }}"
+              echo "- Release existed: ${{ steps.publish.outputs.release_exists }}"
+            fi
+            
+            if [ "${{ steps.context.outcome }}" = "failure" ] || [ "${{ steps.publish.outcome }}" = "failure" ]; then
+              if [ -n "${RELEASE_COMPARED_REFS}" ]; then
+                echo "- Compared refs: ${RELEASE_COMPARED_REFS}"
+              fi
+            else
+              echo "- Comparable: ${{ steps.context.outputs.comparable }}"
+              echo "- Compared refs: ${{ steps.context.outputs.ref }} -> ${{ github.event.workflow_run.head_sha }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,13 @@ $RECYCLE.BIN/
 .idea/runConfigurations.xml
 /.idea/csv-editor.xml
 /.idea/sonarlint/securityhotspotstore/index.pb
+
+# cursor config
+/.cursor/
+
+# codex config
+/.codex
+
+# Antigravity config
+/.agent
+/.agents/

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,409 @@
+# cosmos-workflow
+
+[English](./README.md) | [中文](./README.zh-CN.md)
+
+`cosmos-workflow` は、`java-cosmos` を前提にした Java のワークフローライブラリです。ワークフロー定義と実行を分けた構成で、少数のコアな入口を通して定義管理とインスタンス操作を提供します。
+
+## 概要
+
+- ワークフローと定義の作成
+- インスタンスの起動
+- 承認フローの進行
+- 単一承認者ノード、複数承認者ノード、ロボットノード
+- バージョン管理
+- `BACK`、`REJECT`、`CANCEL`、`RETRIEVE`、`REBINDING`、`RELOCATE` などの操作
+- プラグイン、通知、承認者展開、制限、独自バリデーションの拡張
+
+主要な入口:
+
+- `ProcessDesign`: ワークフロー定義とバージョン管理
+- `ProcessEngine`: インスタンスの開始と操作
+
+組み込み機能:
+
+- 開始ノードと終了ノード
+- 単一承認者ノード
+- `OR` / `AND` を持つ複数承認者ノード
+- ロボットノード
+- ワークフローのバージョン管理
+- `NEXT`、`BACK`、`REJECT`、`CANCEL`、`WITHDRAW`、`RETRIEVE`、`REBINDING`、`RELOCATE` などの操作
+
+## 要件
+
+- Java 17
+- Maven
+- `java-cosmos` 互換のバックエンド
+
+バックエンドは Cosmos DB、MongoDB、Postgres を利用できます。Postgres と MongoDB では、初回アクセス時に必要なテーブルやインデックスが自動で初期化されます。
+
+## インストール
+
+依存関係:
+
+```xml
+<dependency>
+  <groupId>jp.co.onehr.workflow</groupId>
+  <artifactId>cosmos-workflow</artifactId>
+  <version>0.2.11</version>
+</dependency>
+```
+
+ビルド:
+
+```bash
+mvn test
+mvn package
+```
+
+## クイックスタート
+
+### 1. データベースを登録する
+
+1 つの論理 `host` に対して 1 つのデータベースと 1 つのコレクションを登録します:
+
+```java
+var host = "tenant-demo";
+var collectionName = "workflow_data";
+
+var db = new CosmosBuilder()
+        .withDatabaseType("postgres")
+        .withConnectionString("jdbc:postgresql://localhost:5432/workflow?user=postgres&password=postgres")
+        .build()
+        .getDatabase("Data");
+
+var configuration = ProcessConfiguration.getConfiguration();
+configuration.registerDB(host, db, collectionName);
+```
+
+Postgres では、必要なテーブルやインデックスは初回アクセス時に自動作成されます。
+
+起動時やコンテナ初期化時に登録フローがある場合は、その中で `registerDB(...)` を 1 回だけ呼び、同じ `host` を使い回します。
+
+デフォルト DB 自動登録に使う環境変数:
+
+```env
+ENABLE_WORKFLOW_DEFAULT_DB=true
+FW_WORKFLOW_CONNECTION_STRING=...
+FW_WORKFLOW_DATABASE_NAME=Data
+FW_WORKFLOW_COLLECTION_NAME=Data
+```
+
+入口オブジェクトの生成:
+
+```java
+var processDesign = configuration.buildProcessDesign();
+var processEngine = configuration.buildProcessEngine();
+```
+
+### 2. グローバル初期化とテナント登録
+
+アプリケーション起動時:
+
+```java
+public final class WorkflowBootstrap {
+
+    private static final ProcessConfiguration configuration = ProcessConfiguration.getConfiguration();
+
+    public static final ProcessDesign processDesign;
+    public static final ProcessEngine processEngine;
+
+    static {
+        configuration.setPartitionSuffix("APP");
+        configuration.registerOperatorService(customOperatorService);
+        configuration.registerPlugin(customPlugin);
+        configuration.registerNotificationSender(customNotificationSender);
+        configuration.registerOperatorLogService(customOperatorLogService);
+        configuration.registerActionRestriction(customActionRestriction);
+        configuration.registerAdminActionRestriction(customAdminActionRestriction);
+        configuration.registerValidationsService(customValidationService);
+
+        processDesign = configuration.buildProcessDesign();
+        processEngine = configuration.buildProcessEngine();
+    }
+
+    private WorkflowBootstrap() {
+    }
+}
+```
+
+`host` ごとの DB 登録:
+
+```java
+public class WorkflowTenantRegistrar {
+
+    public void register(String host, CosmosDatabase db, String collectionName) {
+        var configuration = ProcessConfiguration.getConfiguration();
+        configuration.registerDB(host, db, collectionName);
+    }
+}
+```
+
+`host` ごとの設定は `registerDB(...)` だけです。その他の `register*` メソッドと `setPartitionSuffix(...)` は単一の `ProcessConfiguration` に保存されるため、プロセス全体の起動設定として 1 回だけ行ってください。
+
+### 3. ワークフローを作成する
+
+```java
+var creation = new WorkflowCreationParam();
+creation.name = "Expense Approval";
+creation.enableOperatorControl = false;
+
+var managerApproval = new SingleNode("Manager Approval");
+managerApproval.operatorId = "manager-1";
+creation.nodes.add(managerApproval);
+
+var workflow = processDesign.createWorkflow(host, creation);
+```
+
+生成結果:
+
+- `Workflow`
+- 初期 `Definition`
+- 自動生成される開始ノードと終了ノード
+
+### 4. 定義を更新する
+
+```java
+var current = processDesign.getCurrentDefinition(host, workflow.id, 0);
+
+var financeApproval = new MultipleNode(
+        "Finance Approval",
+        ApprovalType.OR,
+        Set.of("finance-1", "finance-2"),
+        Set.of()
+);
+
+current.nodes.add(2, financeApproval);
+
+var definitionParam = new DefinitionParam();
+definitionParam.workflowId = workflow.id;
+definitionParam.enableOperatorControl = false;
+definitionParam.nodes.addAll(current.nodes);
+
+processDesign.upsertDefinition(host, definitionParam);
+```
+
+バージョン管理が有効な場合、`upsertDefinition` は新しい定義バージョンを作成します。無効な場合は現在の定義を更新します。
+
+### 5. インスタンスを開始する
+
+```java
+var application = new ApplicationParam();
+application.workflowId = workflow.id;
+application.applicant = "employee-1";
+application.comment = "April expense claim";
+
+var instance = processEngine.startInstance(host, application);
+```
+
+### 6. インスタンスを進める
+
+```java
+var extendParam = new ActionExtendParam();
+extendParam.comment = "Approved by manager";
+
+var result = processEngine.resolve(
+        host,
+        instance.id,
+        Action.NEXT,
+        "manager-1",
+        extendParam
+);
+
+instance = result.instance;
+```
+
+## 主要 API
+
+### 定義 API
+
+`ProcessDesign` の公開メソッド:
+
+- `createWorkflow(host, WorkflowCreationParam)`
+- `updateWorkflow(host, WorkflowUpdatingParam)`
+- `getWorkflow(host, workflowId)`
+- `readWorkflow(host, workflowId)`
+- `deleteWorkflow(host, workflowId)`
+- `findWorkflows(host, Condition)`
+- `upsertDefinition(host, DefinitionParam)`
+- `getDefinition(host, definitionId)`
+- `getCurrentDefinition(host, workflowId, version)`
+- `findDefinitions(host, Condition)`
+
+### 実行 API
+
+`ProcessEngine` の公開メソッド:
+
+- `startInstance(host, ApplicationParam)`
+- `getInstance(host, instanceId)`
+- `getInstanceWithOps(host, instanceId, operatorId)`
+- `resolve(host, instanceId, Action, operatorId)`
+- `resolve(host, instanceId, Action, operatorId, ActionExtendParam)`
+- `rebinding(host, instanceId, operatorId, RebindingParam)`
+- `bulkRebinding(host, workflowId, operatorId, BulkRebindingParam)`
+- `relocate(host, definitionId, operatorId, RelocateParam)`
+- `findInstances(host, Condition)`
+- `migrationInstance(host, Instance)`
+
+## 操作の説明
+
+`ProcessEngine.resolve(...)` は `Action` によって現在のインスタンス操作を選択します。
+
+- `SAVE`: 現在のノードに留まる
+- `NEXT`: 次のノードへ進む
+- `BACK`: 戻る。追加情報が必要な場合は `ActionExtendParam.backMode` と `backNodeId` を使う
+- `CANCEL`: 状態を `CANCELED` に設定する
+- `REJECT`: 状態を `REJECTED` に設定する
+- `WITHDRAW`: インスタンスをメインパーティションから削除し、元データのコピーをリサイクル用パーティションへ移す。既定では 90 日後に TTL で失効する
+- `RETRIEVE`: 次ノードから前の担当者側へ引き戻す
+- `REBINDING`: インスタンスを別の定義バージョンに再バインドする
+- `RELOCATE`: 指定ノードへ移動する
+- `APPLY`: `startInstance(...)` が書き込む初期ログの操作名。明示的に実行した場合は、先頭ノードに戻して状態を `PROCESSING` に設定する
+- `REAPPLY`: 状態が `PROCESSING` で先頭ノードにあるときの再申請。ノード遷移は `NEXT` と同じで、ログ上の操作名は `REAPPLY` のまま
+
+`ActionExtendParam` の関連フィールド:
+
+- `comment`: 操作ログに保存されるコメント
+- `instanceContext`: この操作で使う業務コンテキスト
+- `logContext`: 操作ログに保存される追加データ
+- `notification`: 登録済み送信処理に渡される通知内容
+- `pluginParam`: プラグイン実行時の入力
+- `operationMode`: `OPERATOR_MODE` または `ADMIN_MODE`
+- `backMode`、`backNodeId`: `BACK` 用の追加入力
+
+## 運用メモ
+
+- `ProcessDesign` と `ProcessEngine` は 1 回だけ生成し、共通サービスの中で保持する
+- DB 登録と拡張ポイント登録は、コンテナ初期化やテナント初期化のタイミングでまとめて行う
+- `host` は固定文字列ではなく、テナントや環境を表す論理キーとして扱う
+- `setPartitionSuffix(...)` は起動時に 1 回だけ設定し、製品やコンテキストごとのデータ分離に使う。`host` ごとに動的変更しない
+- `upsertDefinition(...)` の前に、承認者 ID の妥当性をアプリケーション側で検証する
+- 製品仕様が決まっている場合は、ラッパーサービス側でデフォルト動作を固定する
+
+一例として、定義更新前に approver ID の妥当性を確認し、ラッパー層で `returnToStartNode` のような既定動作を固定する構成があります。
+
+## よく使うパラメータ
+
+### `WorkflowCreationParam`
+
+フィールド:
+
+- `name`: ワークフロー名
+- `id`: 任意のワークフロー ID
+- `enableVersion`: 定義変更時に新しいバージョンを作るか
+- `enableOperatorControl`: ノードの承認者を `allowedOperatorIds` で制限するか
+- `allowedOperatorIds`: 許可された承認者 ID 一覧
+- `nodes`: 開始ノードと終了ノードの間に入るカスタムノード
+- `startNodeName`, `endNodeName`: 自動生成ノードの表示名
+- `startNodeConfiguration`, `endNodeConfiguration`: それぞれのノードに保持させる任意設定
+- `returnToStartNode`: `REJECT` または `CANCEL` 時に先頭ノードへ戻すか
+
+デフォルト:
+
+- バージョン管理は有効
+- 承認者制御は有効
+- 初期申請モードは `SELF`
+- カスタムノードがなければ `Start -> End`
+
+### `DefinitionParam`
+
+フィールド:
+
+- `workflowId`: 対象ワークフロー ID
+- `nodes`: 保存する完全なノード一覧
+- `applicationModes`: `SELF` や `PROXY` などの申請モード
+- `enableOperatorControl`
+- `allowedOperatorIds`
+- `returnToStartNode`
+
+`nodes` は保存対象となる完全なノード一覧です。既存定義の更新時には、現在の開始ノードと終了ノードを含みます。
+
+### `ApplicationParam`
+
+フィールド:
+
+- `workflowId`: 対象ワークフロー ID
+- `applicationMode`: `SELF` または `PROXY`
+- `applicant`: 申請者 ID
+- `proxyApplicant`: 代理申請時の元の申請者
+- `comment`: 初回申請コメント
+- `instanceContext`: インスタンスに紐づく業務コンテキスト
+- `logContext`: 操作ログに載せる追加情報
+- `notification`: 通知送信に渡すペイロード
+
+### `ActionExtendParam`
+
+フィールド:
+
+- `comment`: 操作コメント
+- `instanceContext`: 更新後の業務コンテキスト
+- `logContext`: 操作ログの追加データ
+- `notification`: 通知ペイロード
+- `pluginParam`: ノードプラグイン向けパラメータ
+- `operationMode`: `OPERATOR_MODE` または `ADMIN_MODE`
+- `backMode`: `Action.BACK` 用の戻り方
+- `backNodeId`: 戻り先ノード ID が必要な場合に使用
+
+### その他
+
+- `WorkflowUpdatingParam`: 名前や `enableVersion` などの更新
+- `RebindingParam`: 単一インスタンスを別バージョン定義へ再バインド
+- `BulkRebindingParam`: 条件に合うインスタンスをまとめて再バインド
+- `RelocateParam`: 指定ノードへ強制移動
+
+## ノード種別
+
+### `SingleNode`
+
+- 主なフィールド: `operatorId`
+
+### `MultipleNode`
+
+- 主なフィールド: `operatorIdSet`、`operatorOrgIdSet`、`approvalType`
+- `approvalType = OR`: 誰か 1 人の承認で進む
+- `approvalType = AND`: 展開後の全承認者の承認が必要
+
+### `RobotNode`
+
+人手を必要としない自動ノードです。
+
+### `StartNode` / `EndNode`
+
+ワークフローの境界ノードで、通常は作成時に自動生成されます。
+
+## 設定
+
+`ProcessConfiguration` の拡張点:
+
+- `registerOperatorService(...)`: 承認者 ID や組織 ID を実際の承認者へ展開
+- `registerPlugin(...)`: カスタムプラグインを登録
+- `registerNotificationSender(...)`: 通知送信を差し込む
+- `registerActionRestriction(...)`: 一般ユーザー向けの操作制御
+- `registerAdminActionRestriction(...)`: 管理者向けの操作制御
+- `registerOperatorLogService(...)`: 操作ログ処理のカスタマイズ
+- `registerContextParamService(...)`: 一括処理向けコンテキスト生成
+- `registerValidationsService(...)`: 独自バリデーション
+- `enableRetrieveResetParallelApproval(true)`: `AND` 承認を retrieve した後に再度全員承認を要求
+- `setPartitionSuffix(...)`: パーティション名へサフィックスを付与。これはプロセス起動時の全体設定であり、`host` ごとの動的オプションではない
+
+## 環境変数
+
+デフォルト DB 自動登録に使う変数:
+
+- `ENABLE_WORKFLOW_DEFAULT_DB`
+- `FW_WORKFLOW_CONNECTION_STRING`
+- `FW_WORKFLOW_DATABASE_NAME`、デフォルトは `Data`
+- `FW_WORKFLOW_COLLECTION_NAME`、デフォルトは `Data`
+
+ルートに `.env` があれば、その内容も読み込みます。
+
+## 補足
+
+- `ProcessConfiguration` はシングルトンです。
+- `host` は登録済み DB とコレクションを引くための論理キーです。
+- 初回アクセス時に必要ならスキーマやインデックスが作られます。
+- `Workflow.currentVersion` が新規インスタンスに使う定義バージョンを制御します。
+- 操作履歴は各インスタンスの `operateLogList` に保存されます。
+
+## License
+
+[MIT](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,407 @@
 # cosmos-workflow
-A light-weight workflow module using nosql database(document type). Provides application, approval and rejection features.
+
+[日本語](./README.ja.md) | [中文](./README.zh-CN.md)
+
+`cosmos-workflow` is a Java workflow library for document-oriented storage built on top of `java-cosmos`. It separates workflow design from workflow execution and provides a small set of core entry points for:
+
+- creating workflows and definitions
+- starting workflow instances
+- moving instances through approval steps
+- extending behavior with plugins, notifications, operator expansion, and validations
+
+## Overview
+
+Main entry points:
+
+- `ProcessDesign`: create and update workflows and definitions
+- `ProcessEngine`: start and operate workflow instances
+
+Built-in features:
+
+- start and end nodes
+- single-approver nodes
+- multi-approver nodes with `OR` or `AND` approval
+- robot nodes for automated steps
+- workflow versioning
+- actions such as `NEXT`, `BACK`, `REJECT`, `CANCEL`, `WITHDRAW`, `RETRIEVE`, `REBINDING`, and `RELOCATE`
+
+## Requirements
+
+- Java 17
+- Maven
+- A `java-cosmos`-compatible backend
+
+The library works with Cosmos DB, MongoDB, or Postgres through `java-cosmos`. For Postgres and MongoDB, schema or index initialization runs automatically on first access.
+
+## Installation
+
+Dependency:
+
+```xml
+<dependency>
+  <groupId>jp.co.onehr.workflow</groupId>
+  <artifactId>cosmos-workflow</artifactId>
+  <version>0.2.11</version>
+</dependency>
+```
+
+Build:
+
+```bash
+mvn test
+mvn package
+```
+
+## Quick Start
+
+### 1. Register a database
+
+Register one logical `host` with one database and one collection:
+
+```java
+var host = "tenant-demo";
+var collectionName = "workflow_data";
+
+var db = new CosmosBuilder()
+        .withDatabaseType("postgres")
+        .withConnectionString("jdbc:postgresql://localhost:5432/workflow?user=postgres&password=postgres")
+        .build()
+        .getDatabase("Data");
+
+var configuration = ProcessConfiguration.getConfiguration();
+configuration.registerDB(host, db, collectionName);
+```
+
+With Postgres, the library creates workflow-related tables and indexes on first access.
+
+If startup or container initialization already handles registration, call `registerDB(...)` there once and reuse the same `host`.
+
+Default DB registration via environment variables:
+
+```env
+ENABLE_WORKFLOW_DEFAULT_DB=true
+FW_WORKFLOW_CONNECTION_STRING=...
+FW_WORKFLOW_DATABASE_NAME=Data
+FW_WORKFLOW_COLLECTION_NAME=Data
+```
+
+Build entry points:
+
+```java
+var processDesign = configuration.buildProcessDesign();
+var processEngine = configuration.buildProcessEngine();
+```
+
+### 2. Global setup and tenant registration
+
+Application startup:
+
+```java
+public final class WorkflowBootstrap {
+
+    private static final ProcessConfiguration configuration = ProcessConfiguration.getConfiguration();
+
+    public static final ProcessDesign processDesign;
+    public static final ProcessEngine processEngine;
+
+    static {
+        configuration.setPartitionSuffix("APP");
+        configuration.registerOperatorService(customOperatorService);
+        configuration.registerPlugin(customPlugin);
+        configuration.registerNotificationSender(customNotificationSender);
+        configuration.registerOperatorLogService(customOperatorLogService);
+        configuration.registerActionRestriction(customActionRestriction);
+        configuration.registerAdminActionRestriction(customAdminActionRestriction);
+        configuration.registerValidationsService(customValidationService);
+
+        processDesign = configuration.buildProcessDesign();
+        processEngine = configuration.buildProcessEngine();
+    }
+
+    private WorkflowBootstrap() {
+    }
+}
+```
+
+Host registration:
+
+```java
+public class WorkflowTenantRegistrar {
+
+    public void register(String host, CosmosDatabase db, String collectionName) {
+        var configuration = ProcessConfiguration.getConfiguration();
+        configuration.registerDB(host, db, collectionName);
+    }
+}
+```
+
+Only `registerDB(...)` is host-scoped. The other `register*` methods and `setPartitionSuffix(...)` write to the singleton `ProcessConfiguration`, so treat them as process-wide startup configuration and set them once before handling workflow requests.
+
+### 3. Create a workflow
+
+```java
+var creation = new WorkflowCreationParam();
+creation.name = "Expense Approval";
+creation.enableOperatorControl = false;
+
+var managerApproval = new SingleNode("Manager Approval");
+managerApproval.operatorId = "manager-1";
+creation.nodes.add(managerApproval);
+
+var workflow = processDesign.createWorkflow(host, creation);
+```
+
+Creates:
+
+- one `Workflow`
+- one initial `Definition`
+- implicit start and end nodes around your custom nodes
+
+### 4. Update the definition
+
+```java
+var current = processDesign.getCurrentDefinition(host, workflow.id, 0);
+
+var financeApproval = new MultipleNode(
+        "Finance Approval",
+        ApprovalType.OR,
+        Set.of("finance-1", "finance-2"),
+        Set.of()
+);
+
+current.nodes.add(2, financeApproval);
+
+var definitionParam = new DefinitionParam();
+definitionParam.workflowId = workflow.id;
+definitionParam.enableOperatorControl = false;
+definitionParam.nodes.addAll(current.nodes);
+
+processDesign.upsertDefinition(host, definitionParam);
+```
+
+With versioning enabled, `upsertDefinition` creates a new definition version. Otherwise it updates the current version in place.
+
+### 5. Start an instance
+
+```java
+var application = new ApplicationParam();
+application.workflowId = workflow.id;
+application.applicant = "employee-1";
+application.comment = "April expense claim";
+
+var instance = processEngine.startInstance(host, application);
+```
+
+### 6. Move the instance forward
+
+```java
+var extendParam = new ActionExtendParam();
+extendParam.comment = "Approved by manager";
+
+var result = processEngine.resolve(
+        host,
+        instance.id,
+        Action.NEXT,
+        "manager-1",
+        extendParam
+);
+
+instance = result.instance;
+```
+
+## Core API
+
+### Design API
+
+`ProcessDesign` exposes:
+
+- `createWorkflow(host, WorkflowCreationParam)`
+- `updateWorkflow(host, WorkflowUpdatingParam)`
+- `getWorkflow(host, workflowId)`
+- `readWorkflow(host, workflowId)`
+- `deleteWorkflow(host, workflowId)`
+- `findWorkflows(host, Condition)`
+- `upsertDefinition(host, DefinitionParam)`
+- `getDefinition(host, definitionId)`
+- `getCurrentDefinition(host, workflowId, version)`
+- `findDefinitions(host, Condition)`
+
+### Runtime API
+
+`ProcessEngine` exposes:
+
+- `startInstance(host, ApplicationParam)`
+- `getInstance(host, instanceId)`
+- `getInstanceWithOps(host, instanceId, operatorId)`
+- `resolve(host, instanceId, Action, operatorId)`
+- `resolve(host, instanceId, Action, operatorId, ActionExtendParam)`
+- `rebinding(host, instanceId, operatorId, RebindingParam)`
+- `bulkRebinding(host, workflowId, operatorId, BulkRebindingParam)`
+- `relocate(host, definitionId, operatorId, RelocateParam)`
+- `findInstances(host, Condition)`
+- `migrationInstance(host, Instance)`
+
+## Actions
+
+`ProcessEngine.resolve(...)` uses `Action` to select the instance operation.
+
+- `SAVE`: stay at the current node
+- `NEXT`: move to the next node
+- `BACK`: move back; use `ActionExtendParam.backMode` and `backNodeId` when required
+- `CANCEL`: set status to `CANCELED`
+- `REJECT`: set status to `REJECTED`
+- `WITHDRAW`: remove the instance from the main partition and move a recycle copy to the recycle partition; by default the recycle entry expires after 90 days
+- `RETRIEVE`: return the instance from the next node to the previous operator
+- `REBINDING`: bind the instance to another definition version
+- `RELOCATE`: move the instance to a specified node
+- `APPLY`: action name used by the initial log written in `startInstance(...)`; as an explicit action, reset to the first node and set status to `PROCESSING`
+- `REAPPLY`: resubmit from the first node while status is `PROCESSING`; node transition is the same as `NEXT`, log action remains `REAPPLY`
+
+Related fields in `ActionExtendParam`:
+
+- `comment`: stored in the operation log
+- `instanceContext`: business context used during the action
+- `logContext`: extra payload stored in the operation log
+- `notification`: notification payload passed to the registered sender
+- `pluginParam`: plugin input for nodes that execute plugins
+- `operationMode`: `OPERATOR_MODE` or `ADMIN_MODE`
+- `backMode`, `backNodeId`: additional input for `BACK`
+
+## Operational notes
+
+- build `ProcessDesign` and `ProcessEngine` once and keep them behind a project-level service
+- register database and extension hooks together during container or tenant initialization
+- use `host` as the tenant or environment key, not just a hard-coded string
+- configure `setPartitionSuffix(...)` once at startup to isolate workflow partitions by product or bounded context; do not change it dynamically per `host`
+- validate approver IDs in your application layer before calling `upsertDefinition(...)`
+- normalize workflow defaults in your wrapper service when your product has fixed rules
+
+One example is validating approver IDs in the application layer before `upsertDefinition(...)`, then overriding defaults such as `returnToStartNode` in the wrapper service.
+
+## Important Parameters
+
+### `WorkflowCreationParam`
+
+Fields:
+
+- `name`: workflow name
+- `id`: optional custom workflow ID
+- `enableVersion`: whether definition changes create new versions
+- `enableOperatorControl`: whether node operators are restricted by `allowedOperatorIds`
+- `allowedOperatorIds`: allowlist used when operator control is enabled
+- `nodes`: custom nodes inserted between the generated start and end nodes
+- `startNodeName`, `endNodeName`: custom names for generated boundary nodes
+- `startNodeConfiguration`, `endNodeConfiguration`: custom payload attached to those boundary nodes
+- `returnToStartNode`: on `REJECT` or `CANCEL`, return to the first node or stay on the current node
+
+Defaults:
+
+- versioning is enabled
+- operator control is enabled
+- the initial application mode is `SELF`
+- a workflow with no custom node becomes `Start -> End`
+
+### `DefinitionParam`
+
+Fields:
+
+- `workflowId`: required target workflow
+- `nodes`: the full node list to persist
+- `applicationModes`: allowed application modes such as `SELF` and `PROXY`
+- `enableOperatorControl`
+- `allowedOperatorIds`
+- `returnToStartNode`
+
+`nodes` is the full node list to persist. When updating an existing definition, it typically includes the current start and end nodes.
+
+### `ApplicationParam`
+
+Fields:
+
+- `workflowId`: target workflow ID
+- `applicationMode`: `SELF` or `PROXY`
+- `applicant`: applicant user ID
+- `proxyApplicant`: original applicant when proxy mode is used
+- `comment`: initial operation comment
+- `instanceContext`: business context stored with the instance
+- `logContext`: extra payload attached to the operation log
+- `notification`: notification payload passed to a registered sender
+
+### `ActionExtendParam`
+
+Fields:
+
+- `comment`: operation comment
+- `instanceContext`: updated business context
+- `logContext`: extra operation log payload
+- `notification`: notification payload
+- `pluginParam`: parameters used by plugins attached to a node
+- `operationMode`: `OPERATOR_MODE` or `ADMIN_MODE`
+- `backMode`: used with `Action.BACK`
+- `backNodeId`: target node when the back strategy needs an explicit node
+
+### Other operation parameters
+
+- `WorkflowUpdatingParam`: update workflow metadata such as `name` and `enableVersion`
+- `RebindingParam`: move one instance to another definition version
+- `BulkRebindingParam`: move many instances by status to another definition version
+- `RelocateParam`: force one instance to a specific node
+
+## Node Types
+
+### `SingleNode`
+
+- field: `operatorId`
+- empty operator IDs fail node validation
+
+### `MultipleNode`
+
+- fields: `operatorIdSet`, `operatorOrgIdSet`, `approvalType`
+- `approvalType = OR`: any approver can move the instance
+- `approvalType = AND`: all expanded approvers must approve
+
+### `RobotNode`
+
+Automated node without manual operators.
+
+### `StartNode` and `EndNode`
+
+Boundary nodes generated automatically during workflow creation.
+
+## Configuration
+
+`ProcessConfiguration` hooks:
+
+- `registerOperatorService(...)`: expand operator IDs or organization IDs into actual approvers
+- `registerPlugin(...)`: register custom node plugins
+- `registerNotificationSender(...)`: send notifications during workflow actions
+- `registerActionRestriction(...)`: hide or block operator actions
+- `registerAdminActionRestriction(...)`: hide or block admin actions
+- `registerOperatorLogService(...)`: customize operation log handling
+- `registerContextParamService(...)`: enrich context for bulk operations
+- `registerValidationsService(...)`: run custom definition validation
+- `enableRetrieveResetParallelApproval(true)`: when retrieving an `AND` approval node, require all parallel approvers to approve again
+- `setPartitionSuffix(...)`: append a suffix to partition names for tests or isolated environments; set it once at startup, not per `host`
+
+## Environment Variables
+
+Used when default DB registration is enabled:
+
+- `ENABLE_WORKFLOW_DEFAULT_DB`: set to `true` to auto-register the default database
+- `FW_WORKFLOW_CONNECTION_STRING`: connection string for `java-cosmos`
+- `FW_WORKFLOW_DATABASE_NAME`: database name, default is `Data`
+- `FW_WORKFLOW_COLLECTION_NAME`: collection name, default is `Data`
+
+If present, `.env` is also read.
+
+## Notes
+
+- `ProcessConfiguration` is a singleton. Configuration is global within the JVM.
+- `host` is a logical key used to select a registered database and collection.
+- The first data access triggers schema or index initialization when needed.
+- `Workflow.currentVersion` controls which definition version is used for new instances.
+- Operation history is stored in `operateLogList` on each instance.
+
+## License
+
+[MIT](./LICENSE.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,408 @@
+# cosmos-workflow
+
+[English](./README.md) | [日本語](./README.ja.md)
+
+`cosmos-workflow` 是一个基于 `java-cosmos` 的 Java 工作流库，面向文档型存储场景。它把“流程设计”和“流程运行”分开，并通过少量核心入口提供工作流定义与实例流转能力。
+
+## 概览
+
+- 创建工作流与定义
+- 启动流程实例
+- 执行审批流转
+- 支持单人审批、多人审批、机器人节点
+- 支持版本控制、回退、撤回、拒绝、重绑定义、强制跳转节点
+- 支持插件、通知、操作者展开、权限限制和自定义校验
+
+主要入口：
+
+- `ProcessDesign`: 流程定义与版本管理
+- `ProcessEngine`: 流程实例启动与流转
+
+内置能力：
+
+- 开始节点和结束节点
+- 单人审批节点
+- 支持 `OR` / `AND` 的多人审批节点
+- 机器人节点
+- 工作流版本控制
+- `NEXT`、`BACK`、`REJECT`、`CANCEL`、`WITHDRAW`、`RETRIEVE`、`REBINDING`、`RELOCATE` 等动作
+
+## 运行要求
+
+- Java 17
+- Maven
+- 一个兼容 `java-cosmos` 的后端
+
+后端可以是 Cosmos DB、MongoDB 或 Postgres。对于 Postgres 和 MongoDB，首次访问时会自动初始化表结构或索引。
+
+## 安装
+
+依赖：
+
+```xml
+<dependency>
+  <groupId>jp.co.onehr.workflow</groupId>
+  <artifactId>cosmos-workflow</artifactId>
+  <version>0.2.11</version>
+</dependency>
+```
+
+构建：
+
+```bash
+mvn test
+mvn package
+```
+
+## 快速开始
+
+### 1. 注册数据库
+
+将一个逻辑 `host` 绑定到一个数据库和一个集合：
+
+```java
+var host = "tenant-demo";
+var collectionName = "workflow_data";
+
+var db = new CosmosBuilder()
+        .withDatabaseType("postgres")
+        .withConnectionString("jdbc:postgresql://localhost:5432/workflow?user=postgres&password=postgres")
+        .build()
+        .getDatabase("Data");
+
+var configuration = ProcessConfiguration.getConfiguration();
+configuration.registerDB(host, db, collectionName);
+```
+
+对于 Postgres，框架会在首次访问时自动创建工作流相关表和索引。
+
+如果启动期或容器初始化阶段已经处理注册，只需要在那里调用一次 `registerDB(...)` 并复用同一个 `host`。
+
+默认数据库自动注册使用以下环境变量：
+
+```env
+ENABLE_WORKFLOW_DEFAULT_DB=true
+FW_WORKFLOW_CONNECTION_STRING=...
+FW_WORKFLOW_DATABASE_NAME=Data
+FW_WORKFLOW_COLLECTION_NAME=Data
+```
+
+构建入口对象：
+
+```java
+var processDesign = configuration.buildProcessDesign();
+var processEngine = configuration.buildProcessEngine();
+```
+
+### 2. 全局初始化与租户注册
+
+应用启动时：
+
+```java
+public final class WorkflowBootstrap {
+
+    private static final ProcessConfiguration configuration = ProcessConfiguration.getConfiguration();
+
+    public static final ProcessDesign processDesign;
+    public static final ProcessEngine processEngine;
+
+    static {
+        configuration.setPartitionSuffix("APP");
+        configuration.registerOperatorService(customOperatorService);
+        configuration.registerPlugin(customPlugin);
+        configuration.registerNotificationSender(customNotificationSender);
+        configuration.registerOperatorLogService(customOperatorLogService);
+        configuration.registerActionRestriction(customActionRestriction);
+        configuration.registerAdminActionRestriction(customAdminActionRestriction);
+        configuration.registerValidationsService(customValidationService);
+
+        processDesign = configuration.buildProcessDesign();
+        processEngine = configuration.buildProcessEngine();
+    }
+
+    private WorkflowBootstrap() {
+    }
+}
+```
+
+按租户或 `host` 注册数据库：
+
+```java
+public class WorkflowTenantRegistrar {
+
+    public void register(String host, CosmosDatabase db, String collectionName) {
+        var configuration = ProcessConfiguration.getConfiguration();
+        configuration.registerDB(host, db, collectionName);
+    }
+}
+```
+
+只有 `registerDB(...)` 是 `host` 级配置。其他 `register*` 方法以及 `setPartitionSuffix(...)` 都写入单例 `ProcessConfiguration`，应在应用启动时统一设置一次，不要随着 `host` 切换。
+
+### 3. 创建工作流
+
+```java
+var creation = new WorkflowCreationParam();
+creation.name = "Expense Approval";
+creation.enableOperatorControl = false;
+
+var managerApproval = new SingleNode("Manager Approval");
+managerApproval.operatorId = "manager-1";
+creation.nodes.add(managerApproval);
+
+var workflow = processDesign.createWorkflow(host, creation);
+```
+
+结果：
+
+- 一个 `Workflow`
+- 一个初始 `Definition`
+- 自动补上的开始节点和结束节点
+
+### 4. 更新定义
+
+```java
+var current = processDesign.getCurrentDefinition(host, workflow.id, 0);
+
+var financeApproval = new MultipleNode(
+        "Finance Approval",
+        ApprovalType.OR,
+        Set.of("finance-1", "finance-2"),
+        Set.of()
+);
+
+current.nodes.add(2, financeApproval);
+
+var definitionParam = new DefinitionParam();
+definitionParam.workflowId = workflow.id;
+definitionParam.enableOperatorControl = false;
+definitionParam.nodes.addAll(current.nodes);
+
+processDesign.upsertDefinition(host, definitionParam);
+```
+
+开启版本管理时，`upsertDefinition` 生成新版本；关闭时，更新当前版本。
+
+### 5. 启动实例
+
+```java
+var application = new ApplicationParam();
+application.workflowId = workflow.id;
+application.applicant = "employee-1";
+application.comment = "April expense claim";
+
+var instance = processEngine.startInstance(host, application);
+```
+
+### 6. 推进实例
+
+```java
+var extendParam = new ActionExtendParam();
+extendParam.comment = "Approved by manager";
+
+var result = processEngine.resolve(
+        host,
+        instance.id,
+        Action.NEXT,
+        "manager-1",
+        extendParam
+);
+
+instance = result.instance;
+```
+
+## 核心接口
+
+### 定义接口
+
+`ProcessDesign` 提供以下接口：
+
+- `createWorkflow(host, WorkflowCreationParam)`
+- `updateWorkflow(host, WorkflowUpdatingParam)`
+- `getWorkflow(host, workflowId)`
+- `readWorkflow(host, workflowId)`
+- `deleteWorkflow(host, workflowId)`
+- `findWorkflows(host, Condition)`
+- `upsertDefinition(host, DefinitionParam)`
+- `getDefinition(host, definitionId)`
+- `getCurrentDefinition(host, workflowId, version)`
+- `findDefinitions(host, Condition)`
+
+### 运行接口
+
+`ProcessEngine` 提供以下接口：
+
+- `startInstance(host, ApplicationParam)`
+- `getInstance(host, instanceId)`
+- `getInstanceWithOps(host, instanceId, operatorId)`
+- `resolve(host, instanceId, Action, operatorId)`
+- `resolve(host, instanceId, Action, operatorId, ActionExtendParam)`
+- `rebinding(host, instanceId, operatorId, RebindingParam)`
+- `bulkRebinding(host, workflowId, operatorId, BulkRebindingParam)`
+- `relocate(host, definitionId, operatorId, RelocateParam)`
+- `findInstances(host, Condition)`
+- `migrationInstance(host, Instance)`
+
+## 动作说明
+
+`ProcessEngine.resolve(...)` 通过 `Action` 选择当前实例的处理动作。
+
+- `SAVE`: 停留在当前节点
+- `NEXT`: 流转到下一个节点
+- `BACK`: 回退；需要附加信息时使用 `ActionExtendParam.backMode` 和 `backNodeId`
+- `CANCEL`: 将状态设为 `CANCELED`
+- `REJECT`: 将状态设为 `REJECTED`
+- `WITHDRAW`: 将实例从主分区移除，并把原始数据写入回收分区；默认会在 90 天后随 TTL 过期
+- `RETRIEVE`: 将实例从下一节点取回到上一操作者
+- `REBINDING`: 将实例绑定到其他定义版本
+- `RELOCATE`: 将实例移动到指定节点
+- `APPLY`: `startInstance(...)` 写入初始日志时使用的动作名；显式调用时，将实例重置到首节点并把状态设为 `PROCESSING`
+- `REAPPLY`: 状态为 `PROCESSING` 且位于首节点时的再次提交；节点流转与 `NEXT` 相同，日志动作名保持为 `REAPPLY`
+
+`ActionExtendParam` 中的相关字段：
+
+- `comment`: 写入操作日志
+- `instanceContext`: 本次动作使用的业务上下文
+- `logContext`: 写入操作日志的扩展数据
+- `notification`: 传给通知发送器的通知内容
+- `pluginParam`: 节点插件执行时使用的输入参数
+- `operationMode`: `OPERATOR_MODE` 或 `ADMIN_MODE`
+- `backMode`、`backNodeId`: `BACK` 的附加参数
+
+## 运行说明
+
+- `ProcessDesign` 和 `ProcessEngine` 只构建一次，放到项目级公共 service 里
+- 在容器初始化、租户初始化或应用启动阶段，把数据库注册和扩展点注册放在一起做
+- `host` 通常作为租户或环境维度的逻辑键使用
+- 在启动期一次性配置 `setPartitionSuffix(...)`，用于不同产品线或上下文的数据隔离；不要按 `host` 动态修改
+- 在调用 `upsertDefinition(...)` 之前，先在业务层校验审批人 ID 是否有效
+- 如果产品规则固定，可以在封装层统一覆盖某些默认行为
+
+一种做法是先在业务层完成 approver 校验，再在封装层覆盖 `returnToStartNode` 这类默认行为。
+
+## 常用参数说明
+
+### `WorkflowCreationParam`
+
+字段：
+
+- `name`: 工作流名称
+- `id`: 可选，自定义工作流 ID
+- `enableVersion`: 是否启用定义版本控制
+- `enableOperatorControl`: 是否限制节点操作者必须出现在 `allowedOperatorIds` 中
+- `allowedOperatorIds`: 允许使用的操作者白名单
+- `nodes`: 自定义节点列表，会插入到自动生成的开始和结束节点之间
+- `startNodeName`, `endNodeName`: 自动生成的边界节点名称
+- `startNodeConfiguration`, `endNodeConfiguration`: 附加到开始或结束节点的自定义配置
+- `returnToStartNode`: 当执行 `REJECT` 或 `CANCEL` 时，是否回到第一个节点
+
+默认值：
+
+- 默认开启版本控制
+- 默认开启操作人限制
+- 默认申请模式是 `SELF`
+- 如果不传自定义节点，流程就是 `Start -> End`
+
+### `DefinitionParam`
+
+字段：
+
+- `workflowId`: 目标工作流 ID
+- `nodes`: 要保存的完整节点列表
+- `applicationModes`: 允许的申请模式，例如 `SELF`、`PROXY`
+- `enableOperatorControl`
+- `allowedOperatorIds`
+- `returnToStartNode`
+
+`nodes` 表示最终要保存的完整节点列表。更新现有定义时，通常包含当前的开始节点和结束节点。
+
+### `ApplicationParam`
+
+字段：
+
+- `workflowId`: 目标工作流 ID
+- `applicationMode`: `SELF` 或 `PROXY`
+- `applicant`: 申请人 ID
+- `proxyApplicant`: 代申请时的原始申请人
+- `comment`: 首次申请备注
+- `instanceContext`: 实例业务上下文
+- `logContext`: 操作日志扩展上下文
+- `notification`: 传给通知发送器的通知内容
+
+### `ActionExtendParam`
+
+字段：
+
+- `comment`: 本次操作备注
+- `instanceContext`: 更新后的实例上下文
+- `logContext`: 操作日志扩展数据
+- `notification`: 通知内容
+- `pluginParam`: 节点插件参数
+- `operationMode`: `OPERATOR_MODE` 或 `ADMIN_MODE`
+- `backMode`: 与 `Action.BACK` 搭配使用
+- `backNodeId`: 某些回退场景下的目标节点 ID
+
+### 其他参数对象
+
+- `WorkflowUpdatingParam`: 更新工作流名称、是否启用版本管理等元信息
+- `RebindingParam`: 将单个实例重绑到指定定义版本
+- `BulkRebindingParam`: 按状态批量重绑实例
+- `RelocateParam`: 强制将实例移动到指定节点
+
+## 节点类型
+
+### `SingleNode`
+
+- 关键字段：`operatorId`
+
+### `MultipleNode`
+
+- 关键字段：`operatorIdSet`、`operatorOrgIdSet`、`approvalType`
+- `approvalType = OR`: 任意一个审批人通过即可
+- `approvalType = AND`: 所有展开后的审批人都需要通过
+
+### `RobotNode`
+
+机器人节点，不需要人工操作者。
+
+### `StartNode` / `EndNode`
+
+流程边界节点，通常在工作流创建时自动生成。
+
+## 配置
+
+`ProcessConfiguration` 扩展点：
+
+- `registerOperatorService(...)`: 把操作者 ID 或组织 ID 展开成真实审批人
+- `registerPlugin(...)`: 注册自定义插件
+- `registerNotificationSender(...)`: 接入通知发送逻辑
+- `registerActionRestriction(...)`: 控制普通操作者可见或可执行的动作
+- `registerAdminActionRestriction(...)`: 控制管理员动作
+- `registerOperatorLogService(...)`: 自定义操作日志处理
+- `registerContextParamService(...)`: 为批量操作补充上下文
+- `registerValidationsService(...)`: 注册自定义定义校验
+- `enableRetrieveResetParallelApproval(true)`: 对 `AND` 并行审批启用 retrieve 后重新全员审批
+- `setPartitionSuffix(...)`: 给分区名追加后缀，可用于测试隔离；这是进程级启动配置，不是按 `host` 动态切换的选项
+
+## 环境变量
+
+默认数据库自动注册使用以下变量：
+
+- `ENABLE_WORKFLOW_DEFAULT_DB`
+- `FW_WORKFLOW_CONNECTION_STRING`
+- `FW_WORKFLOW_DATABASE_NAME`，默认值是 `Data`
+- `FW_WORKFLOW_COLLECTION_NAME`，默认值是 `Data`
+
+如果项目根目录存在 `.env`，库也会读取其中的配置。
+
+## 补充说明
+
+- `ProcessConfiguration` 是单例，JVM 内全局共享。
+- `host` 是逻辑标识，用来选取已注册的数据库和集合名。
+- 首次访问数据时，框架会按需创建表或索引。
+- `Workflow.currentVersion` 决定新实例使用哪个定义版本。
+- 每个实例的操作历史保存在 `operateLogList` 中。
+
+## License
+
+[MIT](./LICENSE.md)

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>jp.co.onehr.workflow</groupId>
     <artifactId>cosmos-workflow</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.10</version>
+    <version>0.2.11</version>
     <name>cosmos-workflow</name>
     <url>https://github.com/one-hr/cosmos-workflow</url>
 

--- a/src/main/java/jp/co/onehr/workflow/constant/Action.java
+++ b/src/main/java/jp/co/onehr/workflow/constant/Action.java
@@ -46,7 +46,7 @@ public enum Action {
     REJECT(new RejectService()),
 
     /**
-     * Withdraw. Withdraw instance means the instance data will be deleted immediately
+     * Withdraw. Remove the instance from the main partition and keep a recycle copy that expires by TTL.
      */
     WITHDRAW(new WithdrawalService()),
 


### PR DESCRIPTION
 ## Summary

  - refine the English, Chinese, and Japanese README files
  - align section structure across all language versions
  - clarify workflow actions and parameter descriptions
  - add a GitHub Actions workflow that creates a tag and release on PR merge to `master`
  - publish only when the version in `pom.xml` changes

  ## Details

  ### README
  - rewrote parts of the documentation to be more reference-style
  - aligned headings and section order across `README.md`, `README.zh-CN.md`, and `README.ja.md`
  - clarified action semantics, especially `APPLY` and `REAPPLY`
  - localized section titles in Chinese and Japanese

  ### GitHub Actions
  - added `release-on-merge.yml`
  - trigger on merged PRs to `master`
  - read version from `pom.xml`
  - create `v<version>` tag and GitHub release
  - skip when the version has not changed
  - skip for `release/*` source branches
  - write workflow summary for skipped or processed runs